### PR TITLE
feat: 支持多图片上传 + Mac快捷键适配

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -633,10 +633,11 @@ function getWebviewContent(reason: string, requestId: string): string {
     // 支持多张图片的数组
     let imageList = [];
     
-    // 检测Mac系统，更新快捷键提示
-    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0 || navigator.userAgent.toUpperCase().indexOf('MAC') >= 0;
+    // 检测Mac系统，更新快捷键提示（兼容多种检测方式）
+    const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.platform) || /Mac/i.test(navigator.userAgent);
     if (isMac) {
-      document.getElementById('pasteKey').textContent = '⌘';
+      const pasteKeyEl = document.getElementById('pasteKey');
+      if (pasteKeyEl) pasteKeyEl.textContent = '⌘';
     }
     
     // Focus textarea on load


### PR DESCRIPTION
## 功能改进

### 多图片上传支持
- 将单图片变量改为数组，支持同时上传多张图片
- 拖拽支持一次性拖入多张图片
- 粘贴支持多张图片（如果剪贴板有多张）
- 新增网格布局预览多图
- 每张图片可单独删除（右上角红色×按钮）
- 支持一键清空全部图片
- 显示图片总数和总大小（如"共 3 张图片 (1.2 MB)"）

### Mac快捷键适配
- 自动检测Mac系统
- Mac上显示 ⌘+V 替代 Ctrl+V

### 技术细节
- `currentImageBase64` 单变量 → `imageList` 数组
- 移除粘贴处理中的 `break`，遍历所有图片
- 拖拽使用 `for` 循环处理所有文件
- 新增 `updateImagePreview()` 函数统一更新UI

---
感谢您的开源项目！🙏